### PR TITLE
fix: 'About' and 'Newsletter' links in header

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,9 +27,9 @@ linkedin: 'ashleybaxter'
 # Navigation
 navigation:
   - text: About
-    url: /about.html
+    url: /about/
   - text: Newsletter
-    url: /newsletter.html
+    url: /newsletter/
 
 # Required Plugins
 plugins_dir:


### PR DESCRIPTION
Fix 'About' and 'Newsletter' links in header, because they were broken links.

Fixes https://github.com/ashleybaxter/iamashley/issues/8